### PR TITLE
Get rid of globals

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,73 +17,80 @@ type Task struct {
 	WorkTime    time.Duration `json:"work_time"`
 }
 
-var tasks []Task
+type TaskList struct {
+	tasks    []Task
+	taskFile string
+}
 
-func printTasks() {
+func NewTaskList(taskFile string) *TaskList {
+	return &TaskList{taskFile: taskFile}
+}
+
+func (t *TaskList) printTasks() {
 	fmt.Println("Tasks:")
 
-	printTaskList(tasks)
+	t.printTaskList()
 
 	totalTime := time.Duration(0)
-	for _, task := range tasks {
+	for _, task := range t.tasks {
 		totalTime += task.WorkTime
 	}
 	fmt.Printf("\nTotal time spent on all tasks: %v\n", totalTime.Truncate(time.Second))
 }
 
-func printTaskList(taskList []Task) {
-	for i, task := range taskList {
+func (t *TaskList) printTaskList() {
+	for i, task := range t.tasks {
 		if !task.Finished {
 			continue
 		}
-		printTask(task, i+1, "Finished")
+		t.printTask(task, i+1, "Finished")
 	}
 	fmt.Println("------------------------------------------")
-	for i, task := range taskList {
+	for i, task := range t.tasks {
 		if task.Finished {
 			continue
 		}
-		printTask(task, i+1, "Unfinished")
+		t.printTask(task, i+1, "Unfinished")
 	}
 }
 
-func printTask(task Task, number int, status string) {
+func (t *TaskList) printTask(task Task, number int, status string) {
 	fmt.Printf("%-5d %-10s %-10v %s\n", number, status, task.WorkTime.Truncate(time.Second), task.Description)
 }
 
-func addTask(description string) {
-	tasks = append(tasks, Task{Description: description, Finished: false})
+func (t *TaskList) addTask(description string) {
+	t.tasks = append(t.tasks, Task{Description: description, Finished: false})
 }
 
-func removeTask(index int) {
-	if index < 1 || index > len(tasks) {
+func (t *TaskList) removeTask(index int) {
+	if index < 1 || index > len(t.tasks) {
 		fmt.Println("Invalid task number")
 		return
 	}
 
-	tasks = append(tasks[:index-1], tasks[index:]...)
+	t.tasks = append(t.tasks[:index-1], t.tasks[index:]...)
 }
 
-func updateTask(index int, description string) {
-	if index < 1 || index > len(tasks) {
+func (t *TaskList) updateTask(index int, description string) {
+	if index < 1 || index > len(t.tasks) {
 		fmt.Println("Invalid task number")
 		return
 	}
 
-	tasks[index-1].Description = description
+	t.tasks[index-1].Description = description
 }
 
-func finishTask(index int) {
-	if index < 1 || index > len(tasks) {
+func (t *TaskList) finishTask(index int) {
+	if index < 1 || index > len(t.tasks) {
 		fmt.Println("Invalid task number")
 		return
 	}
 
-	tasks[index-1].Finished = true
+	t.tasks[index-1].Finished = true
 }
 
-func workOnTask(index int) {
-	if index < 1 || index > len(tasks) {
+func (t *TaskList) workOnTask(index int) {
+	if index < 1 || index > len(t.tasks) {
 		fmt.Println("Invalid task number")
 		return
 	}
@@ -94,24 +101,24 @@ func workOnTask(index int) {
 	reader := bufio.NewReader(os.Stdin)
 	_, _ = reader.ReadString('\n')
 
-	tasks[index-1].WorkTime += time.Since(start)
+	t.tasks[index-1].WorkTime += time.Since(start)
 }
 
-func handleCommand(input string) {
+func handleCommand(input string, taskList *TaskList) {
 	tokens := strings.Split(input, " ")
 	command := tokens[0]
 
 	switch command {
 	case "add":
-		addTask(strings.Join(tokens[1:], " "))
+		taskList.addTask(strings.Join(tokens[1:], " "))
 	case "remove":
-		removeTask(atoi(tokens[1]))
+		taskList.removeTask(atoi(tokens[1]))
 	case "update":
-		updateTask(atoi(tokens[1]), strings.Join(tokens[2:], " "))
+		taskList.updateTask(atoi(tokens[1]), strings.Join(tokens[2:], " "))
 	case "finish":
-		finishTask(atoi(tokens[1]))
+		taskList.finishTask(atoi(tokens[1]))
 	case "work":
-		workOnTask(atoi(tokens[1]))
+		taskList.workOnTask(atoi(tokens[1]))
 	default:
 		fmt.Println("Invalid command")
 	}
@@ -125,47 +132,48 @@ func atoi(str string) int {
 	return result
 }
 
-func saveTasksToFile() {
-	taskData, err := json.Marshal(tasks)
+func (t *TaskList) saveTasksToFile() {
+	taskData, err := json.Marshal(t.tasks)
 	if err != nil {
 		fmt.Println("Error saving tasks to file:", err)
 		return
 	}
 
-	err = ioutil.WriteFile(taskFile, taskData, 0644)
+	err = ioutil.WriteFile(t.taskFile, taskData, 0644)
 	if err != nil {
 		fmt.Println("Error saving tasks to file:", err)
 	}
 }
 
-func loadTasksFromFile() {
-	taskData, err := ioutil.ReadFile(taskFile)
+func (t *TaskList) loadTasksFromFile() {
+	taskData, err := ioutil.ReadFile(t.taskFile)
 	if err != nil {
 		fmt.Println("No existing task file found. Starting with an empty task list.")
 		return
 	}
 
-	err = json.Unmarshal(taskData, &tasks)
+	err = json.Unmarshal(taskData, &t.tasks)
 	if err != nil {
 		fmt.Println("Error loading tasks from file:", err)
 	}
 }
 
-var taskFile string
-
 func main() {
+	var taskFile string
+
 	if len(os.Args) > 1 {
 		taskFile = os.Args[1]
 	} else {
 		taskFile = "tasks.dat"
 	}
 
-	loadTasksFromFile()
+	taskList := NewTaskList(taskFile)
+	taskList.loadTasksFromFile()
 
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		printTasks()
+		taskList.printTasks()
 
 		fmt.Print("> ")
 		input, _ := reader.ReadString('\n')
@@ -175,10 +183,10 @@ func main() {
 			break
 		}
 
-		handleCommand(input)
+		handleCommand(input, taskList)
 	}
 
-	saveTasksToFile()
+	taskList.saveTasksToFile()
 
 	fmt.Println("Task list saved to file. Goodbye!")
 }


### PR DESCRIPTION
The code has been refactored to encapsulate the operations on the tasks within a struct called 'TaskList'. This helps to remove the global variable tasks and brings in more modularity and clarity to the code. The functions which were earlier standalone functions have now been made methods on the TaskList struct. Also the 'handleCommand' function now accepts the TaskList object as a parameter so it can operate on its tasks.

Resolves #23