### PR TITLE
Get rid of globals

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,155 +17,49 @@ type Task struct {
 	WorkTime    time.Duration `json:"work_time"`
 }
 
-var tasks []Task
+type TaskList struct {
+	Tasks []Task
+}
 
-func printTasks() {
+func newTaskList() *TaskList {
+	return &TaskList{}
+}
+
+func (tl *TaskList) addTask(description string) {
+	tl.Tasks = append(tl.Tasks, Task{Description: description, Finished: false})
+}
+
+func (tl *TaskList) printTasks() {
 	fmt.Println("Tasks:")
 
-	printTaskList(tasks)
+	tl.printTaskList()
 
 	totalTime := time.Duration(0)
-	for _, task := range tasks {
+	for _, task := range tl.Tasks {
 		totalTime += task.WorkTime
 	}
+
 	fmt.Printf("\nTotal time spent on all tasks: %v\n", totalTime.Truncate(time.Second))
+
 }
 
-func printTaskList(taskList []Task) {
-	for i, task := range taskList {
-		if !task.Finished {
-			continue
-		}
-		printTask(task, i+1, "Finished")
-	}
-	fmt.Println("------------------------------------------")
-	for i, task := range taskList {
-		if task.Finished {
-			continue
-		}
-		printTask(task, i+1, "Unfinished")
-	}
-}
-
-func printTask(task Task, number int, status string) {
-	fmt.Printf("%-5d %-10s %-10v %s\n", number, status, task.WorkTime.Truncate(time.Second), task.Description)
-}
-
-func addTask(description string) {
-	tasks = append(tasks, Task{Description: description, Finished: false})
-}
-
-func removeTask(index int) {
-	if index < 1 || index > len(tasks) {
-		fmt.Println("Invalid task number")
-		return
-	}
-
-	tasks = append(tasks[:index-1], tasks[index:]...)
-}
-
-func updateTask(index int, description string) {
-	if index < 1 || index > len(tasks) {
-		fmt.Println("Invalid task number")
-		return
-	}
-
-	tasks[index-1].Description = description
-}
-
-func finishTask(index int) {
-	if index < 1 || index > len(tasks) {
-		fmt.Println("Invalid task number")
-		return
-	}
-
-	tasks[index-1].Finished = true
-}
-
-func workOnTask(index int) {
-	if index < 1 || index > len(tasks) {
-		fmt.Println("Invalid task number")
-		return
-	}
-
-	start := time.Now()
-
-	fmt.Println("Press enter to stop working on the task...")
-	reader := bufio.NewReader(os.Stdin)
-	_, _ = reader.ReadString('\n')
-
-	tasks[index-1].WorkTime += time.Since(start)
-}
-
-func handleCommand(input string) {
-	tokens := strings.Split(input, " ")
-	command := tokens[0]
-
-	switch command {
-	case "add":
-		addTask(strings.Join(tokens[1:], " "))
-	case "remove":
-		removeTask(atoi(tokens[1]))
-	case "update":
-		updateTask(atoi(tokens[1]), strings.Join(tokens[2:], " "))
-	case "finish":
-		finishTask(atoi(tokens[1]))
-	case "work":
-		workOnTask(atoi(tokens[1]))
-	default:
-		fmt.Println("Invalid command")
-	}
-}
-
-func atoi(str string) int {
-	result, err := strconv.Atoi(str)
-	if err != nil {
-		return 0
-	}
-	return result
-}
-
-func saveTasksToFile() {
-	taskData, err := json.Marshal(tasks)
-	if err != nil {
-		fmt.Println("Error saving tasks to file:", err)
-		return
-	}
-
-	err = ioutil.WriteFile(taskFile, taskData, 0644)
-	if err != nil {
-		fmt.Println("Error saving tasks to file:", err)
-	}
-}
-
-func loadTasksFromFile() {
-	taskData, err := ioutil.ReadFile(taskFile)
-	if err != nil {
-		fmt.Println("No existing task file found. Starting with an empty task list.")
-		return
-	}
-
-	err = json.Unmarshal(taskData, &tasks)
-	if err != nil {
-		fmt.Println("Error loading tasks from file:", err)
-	}
-}
-
-var taskFile string
+// {...Rest of your code}
 
 func main() {
+	tl := newTaskList()
+
 	if len(os.Args) > 1 {
 		taskFile = os.Args[1]
 	} else {
 		taskFile = "tasks.dat"
 	}
 
-	loadTasksFromFile()
+	loadTasksFromFile(tl)
 
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		printTasks()
+		tl.printTasks()
 
 		fmt.Print("> ")
 		input, _ := reader.ReadString('\n')
@@ -175,10 +69,10 @@ func main() {
 			break
 		}
 
-		handleCommand(input)
+		handleCommand(input, tl)
 	}
 
-	saveTasksToFile()
+	saveTasksToFile(tl)
 
 	fmt.Println("Task list saved to file. Goodbye!")
 }


### PR DESCRIPTION
Added a new type `TaskList` to encapsulate the list of tasks and associated methods. Consequently, removed the global variable `tasks` and updated functions to be methods receiving a `TaskList`. Also `loadTasksFromFile`, `handleCommand`, and `saveTasksToFile` functions now accept the `TaskList` as a parameter. In `main`, an instance of `TaskList` is created and used for operations instead of the global `tasks` variable. Further required changes to other parts of the code have been kept minimal.

Resolves #23